### PR TITLE
Only use basename(file) for log path

### DIFF
--- a/src/SA/CpeSdk/CpeLogger.php
+++ b/src/SA/CpeSdk/CpeLogger.php
@@ -29,7 +29,7 @@ class CpeLogger
         if (!file_exists($this->logPath))
             mkdir($this->logPath, 0755, true);
 
-        $file = $argv[0];
+        $file = basename($argv[0]);
         if ($suffix)
             $file .= "-".$suffix;
         // Append progname to the path


### PR DESCRIPTION
In cases where $argv[0] is the full path of the file, it causes an error
when logging. Only use the basename() when constructing the log filename.
