### PR TITLE
Removed custom checks for AWS auth data

### DIFF
--- a/src/SA/CpeSdk/Swf/CpeSwfHandler.php
+++ b/src/SA/CpeSdk/Swf/CpeSwfHandler.php
@@ -14,22 +14,16 @@ use SA\CpeSdk;
 class CpeSwfHandler
 {
     public $swf;
-    
+
     public function __construct()
     {
         # Check if preper env vars are setup
         if (!($region = getenv("AWS_DEFAULT_REGION")))
             throw new CpeSdk\CpeException("Set 'AWS_DEFAULT_REGION' environment variable!");
 
-        if (!getenv('AWS_ACCESS_KEY_ID'))
-            throw new CpeSdk\CpeException("Set 'AWS_ACCESS_KEY_ID' environment variable!");
-        
-        if (!getenv('AWS_SECRET_ACCESS_KEY'))
-            throw new CpeSdk\CpeException("Set 'AWS_SECRET_ACCESS_KEY' environment variable!");
-        
         // SWF client
         $this->swf = SwfClient::factory(array(
-                'region'  => $region
-            ));
+            'region'  => $region
+        ));
     }
 }


### PR DESCRIPTION
There were some checks for environment variables in the Swf handler
class, which causes anything using the class to fatal error out, even if
valid credentials are supplied to the client via another method.

Removed the credentials check, as the aws-php-sdk library will check for
credentials on its own anyway.
